### PR TITLE
changed droid projects to not auto-target the lastest framework

### DIFF
--- a/Source/MobileTemplate.Droid.Test/MobileTemplate.Droid.Test.csproj
+++ b/Source/MobileTemplate.Droid.Test/MobileTemplate.Droid.Test.csproj
@@ -15,7 +15,7 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <NuGetPackageImportStamp>

--- a/Source/MobileTemplate.Droid/MobileTemplate.Droid.csproj
+++ b/Source/MobileTemplate.Droid/MobileTemplate.Droid.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
+    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
     <AndroidSupportedAbis>armeabi,armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions />


### PR DESCRIPTION
The droid projects were previously auto-targeting the latest Android framework version. 
This causes the csproj files to change whenever the solution is loaded. and could cause bad surprises if the new frameworks aren't exactly compatible with the app. It should be safer to update the target framework after vetting that new versions work as expected.